### PR TITLE
fix and verify the macOS build instructions

### DIFF
--- a/docs/build-macos.md
+++ b/docs/build-macos.md
@@ -1,15 +1,24 @@
 # Building on macOS
 
-> [!WARNING]
-> These instructions are taken verbatim from upstream DOSBox Staging and
-> have not been tested with dosbox-automation. Nobody on the project
-> currently builds on macOS. They should work, since the build system is
-> shared with upstream, but you are in untested territory - reports and
-> fixes are welcome.
+> [!NOTE]
+> This page started as a copy of the DOSBox Staging instructions, from when
+> this project was downstream of it. That is history now, not a live
+> relationship, and the two build systems have diverged.
+>
+> A release build has since been completed and run on macOS 26.6 / Apple
+> Silicon (M3 Pro, Apple clang 21, CMake 4.4.2). All vcpkg dependencies and
+> the project itself compiled without errors, and the emulator, web server
+> and REST API work. That build was configured by hand rather than through
+> `--preset=release-macos`, because the Xcode generator was not usable on
+> that machine. See [Troubleshooting tips](#troubleshooting-tips).
+>
+> macOS is still not covered by CI and no macOS binaries are published.
+> Reports and fixes remain welcome.
 
-macOS builds can be created using the CMake build tool, compiled using the
-Clang compiler, and provided with dependencies using the Homebrew or MacPorts
-package managers.
+macOS builds can be created using the CMake build tool and compiled using the
+Clang compiler. Build tools come from the Homebrew or MacPorts package
+managers; the library dependencies themselves come from vcpkg, which the
+macOS presets require (see [Installing vcpkg](#installing-vcpkg)).
 
 We recommend using CMake with presets because they're CI-tested and produce a
 binary using consistent compiler flags. Run `cmake --list-presets` to list the
@@ -74,13 +83,28 @@ agreements again if the CMake build step fails.
     sudo port install cmake ccache pkgconfig python314
     ```
 
-## Building
+## Installing vcpkg
 
-Once you have dependencies installed using either environment, clone the
-repository:
+Every macOS preset sets `CMAKE_TOOLCHAIN_FILE` to
+`$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake`, so vcpkg provides the
+library dependencies (SDL3, fluidsynth, libmt32emu, opusfile and the rest,
+per `vcpkg.json`) and `VCPKG_ROOT` must be set before configuring:
 
 ```shell
-git clone https://github.com/dosbox-staging/dosbox-staging.git
+git clone https://github.com/microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
+export VCPKG_ROOT="$PWD/vcpkg"
+```
+
+The first configure builds all dependencies from source, which takes a while;
+later configures reuse the binary cache.
+
+## Building
+
+Once you have the build tools and vcpkg installed, clone the repository:
+
+```shell
+git clone https://github.com/dosbox-automation/dosbox-automation.git
 ```
 
 To build the debug version, execute the following from the repo root:
@@ -105,6 +129,35 @@ cmake --build --preset=release-macos
 - **Random CMake errors**. --- You might need to run `sudo xcodebuild
   -license` to accept the license agreements again. This usually happens after
   an Xcode upgrade.
+
+- **The macOS presets fail with "No CMAKE_C_COMPILER could be found".** ---
+  All four macOS presets use the Xcode generator, so this is the same
+  first-launch problem as above rather than anything preset-specific; check
+  it with `xcodebuild -checkFirstLaunchStatus` (a non-zero exit means the
+  components are missing) and fix it with `sudo xcodebuild -runFirstLaunch`.
+  A quick way to tell the generator apart from the project is to configure a
+  two-line CMake project with `-G Xcode`; if that also fails, the toolchain is
+  at fault. If you cannot complete the first launch, configuring by hand with
+  another generator works and produces a usable binary:
+
+    ```shell
+    cmake -S . -B build/release-macos -G "Unix Makefiles" \
+      -DIS_PRESET_USED=TRUE \
+      -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+      -DVCPKG_TARGET_TRIPLET=arm64-osx \
+      -DCMAKE_OSX_ARCHITECTURES=arm64 \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build build/release-macos -j$(sysctl -n hw.ncpu)
+    ```
+
+- **`RENDER: Error setting fallback shaders, exiting` on first run.** --- A
+  CMake build tree is not a self-contained install; `resources/` is located
+  relative to the working directory (or `<binary>/../Resources`). Running the
+  freshly built binary from inside `build/<preset>/` therefore finds no GLSL
+  shaders, and the missing fallback shader is fatal. Run it from the repo
+  root, or copy `resources/shaders` and `resources/shader-presets` into
+  `~/Library/Preferences/dosbox-automation/`.
 
 
 ## Offline documentation


### PR DESCRIPTION
# Description

Resubmission of #4, reworked to follow CONTRIBUTING.md and this template.

`docs/build-macos.md` says nobody on the project builds on macOS and invites
reports. This is one, plus fixes for two things that stop the page working if
followed literally:

- The clone URL points at `dosbox-staging/dosbox-staging` instead of this
  project.
- The page says dependencies come from Homebrew or MacPorts, but every macOS
  preset sets `CMAKE_TOOLCHAIN_FILE` to
  `$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake`. vcpkg supplies the
  libraries and `VCPKG_ROOT` has to be set before configuring. Added a section
  for it.

Two troubleshooting entries came out of the attempt:

- `RENDER: Error setting fallback shaders, exiting` on first run. A CMake
  build tree is not a self-contained install, and `resources/` is resolved
  relative to the working directory (or `<binary>/../Resources`), so running
  the freshly built binary from inside `build/<preset>/` finds no GLSL shaders
  and the missing fallback is fatal. Verified by removing the copies I had put
  in `~/Library/Preferences/dosbox-automation/` and running from the repo
  root, where it starts and auto-selects `crt-hyllian:vga-1440p`.
- The macOS presets all use the Xcode generator. On this machine that
  generator could not find a compiler, including for a two line
  `project(t C)` test, so the toolchain was at fault rather than this repo.
  `xcodebuild -checkFirstLaunchStatus` exits non-zero here, which is the
  existing "pending Xcode updates" tip, but it surfaces from the preset rather
  than from the compiler check that tip describes. I could not run
  `sudo xcodebuild -runFirstLaunch` on that machine to confirm the fix, so the
  entry says how to check and gives a manual configure as a fallback instead
  of asserting a cause.

Because of that, the build reported below was configured by hand rather than
through `--preset=release-macos`. The header note says so rather than implying
the preset path was exercised.

Also addressed your point about DOSBox Staging: the page no longer claims a
live shared build system, only the historical origin.

No binary is offered. Release artifacts belong to your CI, and an unsigned,
un-notarized macOS build from a third party would be blocked by Gatekeeper.
Happy to test macOS changes on Apple Silicon if useful.

# Manual testing

Test configuration:

- macOS 26.6 (25G76), Apple M3 Pro, arm64
- Apple clang 21.0.0 (clang-2100.1.1.101)
- CMake 4.4.2, Xcode 26.6 (17F113)
- vcpkg bootstrapped from microsoft/vcpkg, triplet arm64-osx
- Boost 1.92.0 and Qt5 not required for this build

Steps to reproduce:

```shell
git clone https://github.com/microsoft/vcpkg.git
./vcpkg/bootstrap-vcpkg.sh
export VCPKG_ROOT="$PWD/vcpkg"

git clone https://github.com/dosbox-automation/dosbox-automation.git
cd dosbox-automation
cmake -S . -B build/release-macos -G "Unix Makefiles" \
  -DIS_PRESET_USED=TRUE \
  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
  -DVCPKG_TARGET_TRIPLET=arm64-osx \
  -DCMAKE_OSX_ARCHITECTURES=arm64 \
  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
  -DCMAKE_BUILD_TYPE=Release
cmake --build build/release-macos -j$(sysctl -n hw.ncpu) 2>&1 | tee build.log
```

Result: all 15 vcpkg dependencies and the project compiled. Configure and
build both exited 0. 698 lines of log, 2 warnings, no errors. Output binary
is `Mach-O 64-bit executable arm64`.

Build log: attached as a comment on this PR.

`dosbox --version` from that binary:

```
dosbox-automation, version 0.84.0-da4 (f8698)

Copyright (C) 2026 The dosbox-automation Team
License: GNU GPL-2.0-or-later <https://www.gnu.org/licenses/gpl-2.0.html>

This is free software, and you are welcome to change and redistribute it under
certain conditions; please read the COPYING file thoroughly before doing so.
There is NO WARRANTY, to the extent permitted by law.
```

Runtime testing, beyond compiling. The emulator was run with
`webserver_enabled = true`, a DOS program was mounted and launched, and these
routes were exercised against it:

- `GET /api/v1/status`, `/dosbox/info`, `/program/state`
- `GET /api/v1/video/frame?format=png`, returned a correct 640x350 PNG
- `GET /api/v1/video/text`, correct behaviour in both text mode and BIOS mode
  16, where it reports `is_text_mode: false`
- `POST /api/v1/input/type` and `/api/v1/input/sequence`
- `GET /api/v1/memory/{offset}/{len}`, `POST /api/v1/memory/search`
- `GET /api/v1/cpu/state`, `/dos/internals`

Reading the guest data segment through `/memory` and cross-checking it against
`ds` from `/cpu/state` and the MCB list from `/dos/internals` agreed exactly,
so those three routes are consistent with each other on this build.

Not run: a sanitizer build.

The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux

Windows and Linux are unticked deliberately. This is a macOS only
documentation change and I have no way to test the other two.

# AI usage

Per CONTRIBUTING.md:

- Model: Anthropic Claude, Opus 5 (model id `claude-opus-5`), used through
  Claude Code.
- The repository's shipped instructions were read and followed:
  `.claude/rules/commits.md`, `.claude/rules/docs-style.md` and
  `docs/CONTRIBUTING.md`. Specifically, no commit prefix, no Co-Authored-By
  trailer, lowercase subject, body wrapped at 72, and no em-dashes or other
  typographic characters in the commit message, the PR description, or the
  added documentation. The six em-dashes still in `docs/build-macos.md` are in
  pre-existing lines that this change does not touch, left alone rather than
  bundled in as an unrelated change.
- I have reviewed the result and I take responsibility for it.

# Checklist

I have:

- [x] followed the project's contributing guidelines and code of conduct.
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [x] split my work into well-defined, bisectable commits, and I named my
      commits well.
- [ ] applied the appropriate labels. Outside contributors cannot set
      labels on this repo, so this one is not mine to tick. It wants the
      documentation label.
- [x] checked that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions.
- [ ] added unit tests where applicable.
- [ ] provided the release notes draft.
- [x] made corresponding changes to the documentation.
