### PR TITLE
Move gtest out of vcpkg defaults for non-test builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,9 @@
       "cacheVariables": {
         "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON"
       }
     },
     {
@@ -22,7 +24,9 @@
       "cacheVariables": {
         "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON"
       }
     },
     {
@@ -58,7 +62,9 @@
       "cacheVariables": {
         "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON"
       }
     },
     {
@@ -70,7 +76,9 @@
       "cacheVariables": {
         "IS_PRESET_USED" : "TRUE",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON"
       }
     },
     {
@@ -84,6 +92,8 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON",
         "CMAKE_XCODE_ATTRIBUTE_COMPILATION_CACHE_ENABLE_CACHING": "YES"
       }
     },
@@ -98,6 +108,8 @@
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON",
         "CMAKE_XCODE_ATTRIBUTE_COMPILATION_CACHE_ENABLE_CACHING": "YES"
       }
     },
@@ -112,7 +124,9 @@
         "CMAKE_OSX_ARCHITECTURES": "arm64",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON"
       }
     },
     {
@@ -126,7 +140,9 @@
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
-        "CMAKE_BUILD_TYPE": "Release"
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON"
       }
     },
     {
@@ -142,6 +158,8 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "VCPKG_HOST_TRIPLET": "x64-windows",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
       },
       "environment": {
@@ -162,6 +180,8 @@
         "CMAKE_BUILD_TYPE": "Release",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "VCPKG_HOST_TRIPLET": "x64-windows",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
       },
       "environment": {
@@ -182,6 +202,8 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "VCPKG_HOST_TRIPLET": "x64-windows",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
       },
       "environment": {
@@ -202,6 +224,8 @@
         "CMAKE_BUILD_TYPE": "Release",
         "VCPKG_TARGET_TRIPLET": "x64-windows-static",
         "VCPKG_HOST_TRIPLET": "x64-windows",
+        "VCPKG_MANIFEST_FEATURES": "tests",
+        "OPT_TESTS": "ON",
         "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
       },
       "environment": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
   "version": "0.84.0",
   "dependencies": [
     "asio",
-    "gtest",
     "iir1",
     "libjpeg-turbo",
     "libmt32emu",
@@ -40,5 +39,13 @@
       "host": true
     }
   ],
+  "features": {
+    "tests": {
+      "description": "Dependencies required for unit tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  },
   "builtin-baseline": "8defa4b8bc4c35071c678e87a0e140dd433489bb"
 }


### PR DESCRIPTION
# Description

gtest is included in all builds, even when tests are not enabled. This patch simply moves gtest out to be an optional dependency which is only included when tests are requested. It should speed up build times and reduce dependencies for all builds.


The change has been manually tested on:

- [ ] Windows
- [x] macOS
- [ ] Linux


# Checklist

_Please tick the items as you have addressed them. Don't remove items; leave the ones that are not applicable unchecked._

I have:

- [x] followed the project's [contributing guidelines](https://github.com/dosbox-automation/dosbox-automation/blob/master/docs/CONTRIBUTING.md) and [code of conduct](https://github.com/dosbox-automation/dosbox-automation/blob/master/docs/CODE_OF_CONDUCT.md).
- [x] performed a self-review of my code.
- [ ] commented on the particularly hard-to-understand areas of my code.
- [ ] split my work into well-defined, bisectable commits, and I [named my commits well](https://github.com/dosbox-automation/dosbox-automation/blob/main/docs/CONTRIBUTING.md#commit-messages).
- [ ] applied the appropriate labels (bug, enhancement, refactoring, documentation, etc.)
- [ ] [checked](https://github.com/dosbox-automation/dosbox-automation/blob/main/scripts/tools/compile-commits.sh) that all my commits can be built.
- [ ] my change has been manually tested on Windows, macOS, and Linux.
- [ ] confirmed that my code does not cause performance regressions (e.g., by running the Quake benchmark).
- [ ] added unit tests where applicable to prove the correctness of my code and to avoid future regressions.
- [ ] provided the release notes draft (for significant user-facing changes).
- [ ] made corresponding changes to the documentation. The user manual and website live in a separate project; note in the PR description when a change needs a manual update.

